### PR TITLE
Fix typo in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -415,7 +415,7 @@ jobs:
 
       - name: Setup environment variables
         run: |
-          # Set enviroment variables to bypass `brew doctor` failures on Tier >=2 configurations
+          # Set environment variables to bypass `brew doctor` failures on Tier >=2 configurations
           if [[ "${MATRIX_NAME}" == "test-bot (Linux arm64)" ]]; then
             echo "HOMEBREW_ARM64_TESTING=1" >> "$GITHUB_ENV"
           elif [[ "${MATRIX_NAME}" == "test-bot (Linux Homebrew glibc)" ]]; then


### PR DESCRIPTION
## Summary
- fix `enviroment` typo in test workflow

## Testing
- `grep -n "environment variables" -n .github/workflows/tests.yml`

------
https://chatgpt.com/codex/tasks/task_e_68618d17531883298a7f501aa303d9f8