### PR TITLE
Fix shellenv documentation formatting

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1489,9 +1489,8 @@ The variables `$HOMEBREW_PREFIX`, `$HOMEBREW_CELLAR` and `$HOMEBREW_REPOSITORY`
 are also exported to avoid querying them multiple times. To help guarantee
 idempotence, this command produces no output when Homebrew's `bin` and `sbin`
 directories are first and second respectively in your `$PATH`. Consider adding
-evaluation of this command's output to your dotfiles (e.g. `~/.bash_profile` or
-~/.zprofile` on macOS and ~/.bashrc` or ~/.zshrc` on Linux) with:
-  `eval "$(brew shellenv)"\`
+evaluation of this command's output to your dotfiles (e.g. `~/.bash_profile` or `~/.zprofile` on macOS and `~/.bashrc` or `~/.zshrc` on Linux) with:
+  `eval "$(brew shellenv)"`
 
 The shell can be specified explicitly with a supported shell name parameter.
 Unknown shells will output POSIX exports.


### PR DESCRIPTION
## Summary
- fix formatting for dotfile paths in `shellenv` docs
- remove stray backslash from `eval` example

## Testing
- `bin/brew style docs/Manpage.md`

------
https://chatgpt.com/codex/tasks/task_e_68618d26a6ac8329a6deea7b56175cb3