### PR TITLE
generate-zap: scan scripting and Electron cache locations

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-zap.rb
+++ b/Library/Homebrew/dev-cmd/generate-zap.rb
@@ -35,6 +35,7 @@ module Homebrew
         "Library",
         "Library/Application Scripts",
         "Library/Application Support",
+        "Library/Application Support/Caches",
         "Library/Application Support/CrashReporter",
         "Library/Application Support/com.apple.sharedfilelist/" \
         "com.apple.LSSharedFileList.ApplicationRecentDocuments",
@@ -53,11 +54,15 @@ module Homebrew
         "Library/Preferences",
         "Library/Preferences/ByHost",
         "Library/Saved Application State",
+        "Library/ScriptingAdditions",
+        "Library/ScriptingDefinitions",
+        "Library/Scripts",
         "Library/WebKit",
         "Music",
       ].freeze, T::Array[String])
 
       SYSTEM_DELETE_PATHS = T.let([
+        "/Library/Application Scripts",
         "/Library/Application Support",
         "/Library/Caches",
         "/Library/Frameworks",
@@ -69,6 +74,8 @@ module Homebrew
         "/Library/PrivilegedHelperTools",
         "/Library/Screen Savers",
         "/Library/ScriptingAdditions",
+        "/Library/ScriptingDefinitions",
+        "/Library/Scripts",
         "/Library/Services",
         "/Users/Shared",
         "/etc/newsyslog.d",

--- a/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
@@ -9,6 +9,22 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
 
   it_behaves_like "parseable arguments"
 
+  describe "scan path configuration" do
+    it "includes scripting and Electron cache locations" do
+      expect(described_class::USER_TRASH_PATHS).to include(
+        "Library/Application Support/Caches",
+        "Library/ScriptingAdditions",
+        "Library/ScriptingDefinitions",
+        "Library/Scripts",
+      )
+      expect(described_class::SYSTEM_DELETE_PATHS).to include(
+        "/Library/Application Scripts",
+        "/Library/ScriptingDefinitions",
+        "/Library/Scripts",
+      )
+    end
+  end
+
   describe "#resolve_app_name_from_cask" do
     it "resolves app name from a cask with an app artifact" do
       app = instance_double(Cask::Artifact::App, target: Pathname.new("TestCask.app"))


### PR DESCRIPTION
### Motivation
- Ensure `brew generate-zap` detects files installed/used by scripting extras and Electron updater caches so generated `zap` stanzas include those locations.

### Description
- Add `"Library/Application Support/Caches"`, `"Library/ScriptingAdditions"`, `"Library/ScriptingDefinitions"`, and `"Library/Scripts"` to `USER_TRASH_PATHS` in `Library/Homebrew/dev-cmd/generate-zap.rb`.
- Add `/Library/Application Scripts`, `/Library/ScriptingDefinitions`, and `/Library/Scripts` to `SYSTEM_DELETE_PATHS` in `Library/Homebrew/dev-cmd/generate-zap.rb`.
- Add an RSpec example to `Library/Homebrew/test/dev-cmd/generate-zap_spec.rb` that asserts the new scan-path entries are present.

### Testing
- Ran `./bin/brew typecheck` and it reported no errors.
- Ran `./bin/brew style --fix --changed` which reported no style checks for the changed files (no violations).
- Ran `./bin/brew tests --only=dev-cmd/generate-zap` and the spec suite for the command passed.
- Ran `./bin/brew tests --online --changed` and `./bin/brew lgtm --online` and both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a196d99b45883299771221265fd2486)